### PR TITLE
Add CDX rebranding module

### DIFF
--- a/addons/cdx_rebranding/__init__.py
+++ b/addons/cdx_rebranding/__init__.py
@@ -1,0 +1,4 @@
+import odoo.release
+
+odoo.release.product_name = "cdx"
+odoo.release.description = "cdx Server"

--- a/addons/cdx_rebranding/__manifest__.py
+++ b/addons/cdx_rebranding/__manifest__.py
@@ -1,0 +1,19 @@
+{
+    'name': 'CDX Rebranding',
+    'summary': 'Replace Odoo branding with cdx',
+    'version': '1.0',
+    'category': 'Tools',
+    'depends': ['web', 'mail'],
+    'data': [
+        'views/webclient_templates.xml',
+    ],
+    'assets': {
+        'web.assets_backend': [
+            'cdx_rebranding/static/src/img/*',
+        ],
+        'web.assets_frontend': [
+            'cdx_rebranding/static/src/img/*',
+        ],
+    },
+    'installable': True,
+}

--- a/addons/cdx_rebranding/i18n/ca.po
+++ b/addons/cdx_rebranding/i18n/ca.po
@@ -1,0 +1,19 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#   * cdx_rebranding
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 18.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-01-01 00:00+0000\n"
+"PO-Revision-Date: 2025-01-01 00:00+0000\n"
+"Last-Translator: CDX Rebranding Module\n"
+"Language-Team: Catalan\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ca\n"
+
+msgid "Odoo"
+msgstr "cdx"

--- a/addons/cdx_rebranding/i18n/en.po
+++ b/addons/cdx_rebranding/i18n/en.po
@@ -1,0 +1,19 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#   * cdx_rebranding
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 18.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-01-01 00:00+0000\n"
+"PO-Revision-Date: 2025-01-01 00:00+0000\n"
+"Last-Translator: CDX Rebranding Module\n"
+"Language-Team: English\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: en\n"
+
+msgid "Odoo"
+msgstr "cdx"

--- a/addons/cdx_rebranding/i18n/es.po
+++ b/addons/cdx_rebranding/i18n/es.po
@@ -1,0 +1,19 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#   * cdx_rebranding
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 18.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-01-01 00:00+0000\n"
+"PO-Revision-Date: 2025-01-01 00:00+0000\n"
+"Last-Translator: CDX Rebranding Module\n"
+"Language-Team: Spanish\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: es\n"
+
+msgid "Odoo"
+msgstr "cdx"

--- a/addons/cdx_rebranding/static/src/img/demo_logo_report.png
+++ b/addons/cdx_rebranding/static/src/img/demo_logo_report.png
@@ -1,0 +1,1 @@
+placeholder for demo_logo_report.png

--- a/addons/cdx_rebranding/static/src/img/favicon.ico
+++ b/addons/cdx_rebranding/static/src/img/favicon.ico
@@ -1,0 +1,1 @@
+placeholder for favicon.ico

--- a/addons/cdx_rebranding/static/src/img/logo.png
+++ b/addons/cdx_rebranding/static/src/img/logo.png
@@ -1,0 +1,1 @@
+placeholder for logo.png

--- a/addons/cdx_rebranding/static/src/img/logo2.png
+++ b/addons/cdx_rebranding/static/src/img/logo2.png
@@ -1,0 +1,1 @@
+placeholder for logo2.png

--- a/addons/cdx_rebranding/static/src/img/logo_inverse_white_206px.png
+++ b/addons/cdx_rebranding/static/src/img/logo_inverse_white_206px.png
@@ -1,0 +1,1 @@
+placeholder for logo_inverse_white_206px.png

--- a/addons/cdx_rebranding/static/src/img/logo_sample.png
+++ b/addons/cdx_rebranding/static/src/img/logo_sample.png
@@ -1,0 +1,1 @@
+placeholder for logo_sample.png

--- a/addons/cdx_rebranding/static/src/img/logo_white.png
+++ b/addons/cdx_rebranding/static/src/img/logo_white.png
@@ -1,0 +1,1 @@
+placeholder for logo_white.png

--- a/addons/cdx_rebranding/static/src/img/odoo-icon-192x192.png
+++ b/addons/cdx_rebranding/static/src/img/odoo-icon-192x192.png
@@ -1,0 +1,1 @@
+placeholder for odoo-icon-192x192.png

--- a/addons/cdx_rebranding/static/src/img/odoo-icon-512x512.png
+++ b/addons/cdx_rebranding/static/src/img/odoo-icon-512x512.png
@@ -1,0 +1,1 @@
+placeholder for odoo-icon-512x512.png

--- a/addons/cdx_rebranding/static/src/img/odoo-icon-ios.png
+++ b/addons/cdx_rebranding/static/src/img/odoo-icon-ios.png
@@ -1,0 +1,1 @@
+placeholder for odoo-icon-ios.png

--- a/addons/cdx_rebranding/static/src/img/odoo-icon.svg
+++ b/addons/cdx_rebranding/static/src/img/odoo-icon.svg
@@ -1,0 +1,1 @@
+placeholder for odoo-icon.svg

--- a/addons/cdx_rebranding/static/src/img/odoo_logo.svg
+++ b/addons/cdx_rebranding/static/src/img/odoo_logo.svg
@@ -1,0 +1,1 @@
+placeholder for odoo_logo.svg

--- a/addons/cdx_rebranding/static/src/img/odoo_logo_dark.svg
+++ b/addons/cdx_rebranding/static/src/img/odoo_logo_dark.svg
@@ -1,0 +1,1 @@
+placeholder for odoo_logo_dark.svg

--- a/addons/cdx_rebranding/static/src/img/odoo_logo_tiny.png
+++ b/addons/cdx_rebranding/static/src/img/odoo_logo_tiny.png
@@ -1,0 +1,1 @@
+placeholder for odoo_logo_tiny.png

--- a/addons/cdx_rebranding/static/src/img/res_company_logo.png
+++ b/addons/cdx_rebranding/static/src/img/res_company_logo.png
@@ -1,0 +1,1 @@
+placeholder for res_company_logo.png

--- a/addons/cdx_rebranding/static/src/img/website_logo.svg
+++ b/addons/cdx_rebranding/static/src/img/website_logo.svg
@@ -1,0 +1,1 @@
+placeholder for website_logo.svg

--- a/addons/cdx_rebranding/views/webclient_templates.xml
+++ b/addons/cdx_rebranding/views/webclient_templates.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <!-- Replace default title with custom product name -->
+    <template id="web.layout" inherit_id="web.layout">
+        <xpath expr="//title" position="replace">
+            <title t-esc="title or 'cdx'"/>
+        </xpath>
+    </template>
+
+    <!-- Replace Powered by message and logo -->
+    <template id="brand_promotion_message" inherit_id="web.brand_promotion_message">
+        <xpath expr="//img[@src='/web/static/img/odoo_logo_tiny.png']" position="replace">
+            <img src="/cdx_rebranding/static/src/img/odoo_logo_tiny.png" alt="cdx" width="62" height="20" style="width: auto; height: 1em; vertical-align: baseline;"/>
+        </xpath>
+        <xpath expr="//t[@t-set='final_message']" position="replace">
+            <t t-set="final_message">Powered by %s%s</t>
+        </xpath>
+    </template>
+
+    <!-- Login footer -->
+    <template id="login_footer" inherit_id="web.login_layout">
+        <xpath expr="//a[contains(@href, 'https://www.odoo.com')]/span" position="replace">
+            <span>cdx</span>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
## Summary
- rename to `cdx_rebranding` for consistency
- change product name to `cdx`
- localize rebranding for English, Spanish and Catalan
- update paths in templates and manifest
- include placeholder text files for logos and icons

## Testing
- `python -m py_compile addons/cdx_rebranding/__init__.py addons/cdx_rebranding/__manifest__.py`
- `python odoo-bin --version` *(fails: ModuleNotFoundError: No module named 'babel')*


------
https://chatgpt.com/codex/tasks/task_e_68665347351c8326958521646becf088