### PR TITLE
Add Codex Simple Login module

### DIFF
--- a/addons/codex_simple_login/__manifest__.py
+++ b/addons/codex_simple_login/__manifest__.py
@@ -1,0 +1,17 @@
+{
+    'name': 'Codex Simple Login',
+    'version': '0.1',
+    'category': 'Tools',
+    'summary': 'Simple login screen with Codex logo',
+    'depends': ['web'],
+    'data': [
+        'views/codex_login_templates.xml',
+    ],
+    'assets': {
+        'web.assets_frontend': [
+            'codex_simple_login/static/src/css/codex_login.css',
+        ],
+    },
+    'installable': True,
+    'application': False,
+}

--- a/addons/codex_simple_login/static/src/css/codex_login.css
+++ b/addons/codex_simple_login/static/src/css/codex_login.css
@@ -1,0 +1,13 @@
+.o_codex_login_container {
+    max-width: 320px;
+    margin: 5% auto;
+    text-align: center;
+}
+.o_codex_login_container img {
+    max-width: 100%;
+    margin-bottom: 1rem;
+}
+.o_codex_login_container form {
+    display: grid;
+    gap: 0.5rem;
+}

--- a/addons/codex_simple_login/static/src/img/codex_logo.png.txt
+++ b/addons/codex_simple_login/static/src/img/codex_logo.png.txt
@@ -1,0 +1,1 @@
+placeholder

--- a/addons/codex_simple_login/views/codex_login_templates.xml
+++ b/addons/codex_simple_login/views/codex_login_templates.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <!-- Override the default login template -->
+    <template id="web.login" name="Login">
+        <t t-call="web.frontend_layout">
+            <t t-set="no_header" t-value="True"/>
+            <t t-set="no_footer" t-value="True"/>
+            <t t-set="body_classname" t-value="'o_codex_login_body'"/>
+            <div class="o_codex_login_container">
+                <img src="/codex_simple_login/static/src/img/codex_logo.png" alt="Codex Logo"/>
+                <form class="oe_login_form" role="form" t-attf-action="/web/login" method="post" onsubmit="this.action = '/web/login' + location.hash">
+                    <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
+                    <input type="text" name="login" placeholder="Username" required="required" class="form-control" autocomplete="username"/>
+                    <input type="password" name="password" placeholder="Password" required="required" class="form-control" autocomplete="current-password"/>
+                    <button type="submit" class="btn btn-primary">Login</button>
+                    <input type="hidden" name="redirect" t-att-value="redirect"/>
+                </form>
+            </div>
+        </t>
+    </template>
+</odoo>

--- a/addons/codex_simple_login/views/codex_login_templates.xml
+++ b/addons/codex_simple_login/views/codex_login_templates.xml
@@ -1,21 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
-    <!-- Override the default login template -->
-    <template id="web.login" name="Login">
-        <t t-call="web.frontend_layout">
-            <t t-set="no_header" t-value="True"/>
-            <t t-set="no_footer" t-value="True"/>
+    <!-- Override login layout to display the Codex logo -->
+    <template id="web.login_layout" inherit_id="web.login_layout">
+        <xpath expr="//div[contains(@class,'border-bottom')]/img" position="replace">
+            <img src="/codex_simple_login/static/src/img/codex_logo.png" alt="Codex Logo" style="max-height:120px; max-width:100%; width:auto"/>
+        </xpath>
+        <xpath expr="//t[@t-set='body_classname']" position="replace">
             <t t-set="body_classname" t-value="'o_codex_login_body'"/>
-            <div class="o_codex_login_container">
-                <img src="/codex_simple_login/static/src/img/codex_logo.png" alt="Codex Logo"/>
-                <form class="oe_login_form" role="form" t-attf-action="/web/login" method="post" onsubmit="this.action = '/web/login' + location.hash">
-                    <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
-                    <input type="text" name="login" placeholder="Username" required="required" class="form-control" autocomplete="username"/>
-                    <input type="password" name="password" placeholder="Password" required="required" class="form-control" autocomplete="current-password"/>
-                    <button type="submit" class="btn btn-primary">Login</button>
-                    <input type="hidden" name="redirect" t-att-value="redirect"/>
-                </form>
-            </div>
-        </t>
+        </xpath>
+        <xpath expr="//a[@href='/web/database/manager']" position="replace"/>
+    </template>
+
+    <!-- Simplify the default login form -->
+    <template id="web.login" inherit_id="web.login" name="Login">
+        <xpath expr="//div[@class='mb-3' and .//label[@for='db']]" position="replace"/>
+        <xpath expr="//t[@t-if='debug']" position="replace"/>
+        <xpath expr="//p[@class='alert alert-danger']" position="replace"/>
+        <xpath expr="//p[@class='alert alert-success']" position="replace"/>
+        <xpath expr="//div[contains(@class,'oe_login_buttons')]/button" position="replace">
+            <button type="submit" class="btn btn-primary">Login</button>
+        </xpath>
     </template>
 </odoo>


### PR DESCRIPTION
## Summary
- introduce `codex_simple_login` module
- override `web.login` template to use a minimal login form
- include basic CSS and placeholder logo

## Testing
- `flake8 addons/codex_simple_login`

------
https://chatgpt.com/codex/tasks/task_e_686e353b2b848326bb73959d8bb8da0a